### PR TITLE
fix(chrome-mac): respect timeoutMs option for Keychain access

### DIFF
--- a/packages/core/src/providers/chromeSqliteMac.ts
+++ b/packages/core/src/providers/chromeSqliteMac.ts
@@ -11,7 +11,7 @@ import { readKeychainGenericPasswordFirst } from './chromium/macosKeychain.js';
 import { resolveCookiesDbFromProfileOrRoots } from './chromium/paths.js';
 
 export async function getCookiesFromChromeSqliteMac(
-	options: { profile?: string; includeExpired?: boolean; debug?: boolean },
+	options: { profile?: string; includeExpired?: boolean; debug?: boolean; timeoutMs?: number },
 	origins: string[],
 	allowlistNames: Set<string> | null
 ): Promise<GetCookiesResult> {
@@ -26,7 +26,7 @@ export async function getCookiesFromChromeSqliteMac(
 	const passwordResult = await readKeychainGenericPasswordFirst({
 		account: 'Chrome',
 		services: ['Chrome Safe Storage'],
-		timeoutMs: 3_000,
+		timeoutMs: options.timeoutMs ?? 3_000,
 		label: 'Chrome Safe Storage',
 	});
 	if (!passwordResult.ok) {


### PR DESCRIPTION
## Summary

The Chrome macOS provider was hardcoding `timeoutMs: 3_000` for Keychain access, ignoring the user-provided timeout option. This is inconsistent with the Edge macOS provider which correctly uses `options.timeoutMs ?? 3_000`.

## Changes

- Added `timeoutMs?: number` to the options type in `getCookiesFromChromeSqliteMac()`
- Changed hardcoded `timeoutMs: 3_000` to `options.timeoutMs ?? 3_000`

## Why

When extracting cookies over SSH or on slower systems, the 3-second hardcoded timeout is often insufficient for Keychain operations. Users should be able to configure this via the existing `timeoutMs` option that works for Edge but was ignored for Chrome.

## Testing

- All existing tests pass
- Verified the fix matches the pattern used in `edgeSqliteMac.ts`